### PR TITLE
Update README voice configuration note

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Sage is an advanced AI assistant designed to understand, learn, and adapt to you
 ### Voice I/O (Optional)
 - **Speech-to-Text (STT)**: Capture voice input using SpeechRecognition and Google Web Speech API
 - **Text-to-Speech (TTS)**: Natural, high-quality speech via Microsoft Edge TTS (edge-tts)
-- **Configurable**: Enable voice modes with the `USE_VOICE` environment variable
+- **Configurable**: Voice mode is toggled in `config.py`
 
 ### Interface Options
 - **Command Line**: Text-based interaction through terminal


### PR DESCRIPTION
## Summary
- clarify the voice configuration docs that voice mode is toggled in `config.py`

## Testing
- `python -m pytest -q` *(fails: No module named 'edge_tts', 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_684b4fd2c6e08330bd28a0fb71c57013